### PR TITLE
Fix code scanning alert no. 5: Incomplete URL substring sanitization

### DIFF
--- a/include/play.js
+++ b/include/play.js
@@ -1,6 +1,7 @@
 const ytdlDiscord = require("ytdl-core-discord");
 const scdl = require("soundcloud-downloader").default;
 const { canModifyQueue, STAY_TIME } = require("../util/DummyBotUtil");
+const urlLib = require("url");
 
 module.exports = {
   async play(song, message) {
@@ -24,16 +25,20 @@ module.exports = {
     try {
       if (song.url.includes("youtube.com")) {
         stream = await ytdlDiscord(song.url, { highWaterMark: 1 << 25 });
-      } else if (song.url.includes("soundcloud.com")) {
-        try {
-          stream = await scdl.downloadFormat(song.url, scdl.FORMATS.MP3, SOUNDCLOUD_CLIENT_ID);
-        } catch (error) {
-          stream = await scdl.downloadFormat(song.url, scdl.FORMATS.MP3, SOUNDCLOUD_CLIENT_ID);
+      } else {
+        const parsedUrl = urlLib.parse(song.url);
+        const host = parsedUrl.host;
+        if (host === "soundcloud.com") {
+          try {
+            stream = await scdl.downloadFormat(song.url, scdl.FORMATS.MP3, SOUNDCLOUD_CLIENT_ID);
+          } catch (error) {
+            stream = await scdl.downloadFormat(song.url, scdl.FORMATS.MP3, SOUNDCLOUD_CLIENT_ID);
+            streamType = "unknown";
+          }
+        } else if (streamRegex.test(song.url)) {
+          stream = song.url;
           streamType = "unknown";
         }
-      } else if (streamRegex.test(song.url)) {
-        stream = song.url;
-        streamType = "unknown";
       }
     } catch (error) {
       if (queue) {


### PR DESCRIPTION
Fixes [https://github.com/Asshat-Gaming/DummyBot/security/code-scanning/5](https://github.com/Asshat-Gaming/DummyBot/security/code-scanning/5)

To fix the problem, we need to parse the URL and validate the host against a whitelist of allowed hosts. This ensures that the URL is genuinely from SoundCloud and not a malicious URL containing "soundcloud.com" in an unexpected location.

1. Parse the URL using the `url` module to extract the host.
2. Check if the host is exactly "soundcloud.com" or any other allowed subdomains.
3. Replace the substring check with this more secure host validation.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
